### PR TITLE
Fix scan limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 local/
 .DS_Store
 .idea/
+.vscode/
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 local/
 .DS_Store
+.idea/
 
 # Logs
 logs

--- a/classes/pdf.php
+++ b/classes/pdf.php
@@ -140,8 +140,6 @@ class pdf {
             INNER JOIN {local_a11y_check} c ON c.id = f.scanid
             WHERE c.status = " . LOCAL_A11Y_CHECK_STATUS_UNCHECKED;
 
-        mtrace($sql);
-        
         $files = $DB->get_records_sql($sql, null, 0, $limit);
 
         return $files;

--- a/classes/pdf.php
+++ b/classes/pdf.php
@@ -38,7 +38,7 @@ class pdf {
      * @param int $limit The number of files to process at a time.
      * @return array
      */
-    public static function get_all_pdfs($limit = 100000) {
+    public static function get_all_pdfs($limit = 5) {
         global $DB;
         $sql = "SELECT f.contenthash, f.pathnamehash, MAX(f.filesize) as filesize
             FROM {files} f
@@ -60,7 +60,7 @@ class pdf {
      * @param int $limit The number of records to process at a time.
      * @return int $limit
      */
-    public static function get_all_records($limit = 100000) {
+    public static function get_all_records($limit = 5) {
         global $DB;
         $sql = "SELECT tp.contenthash as contenthash, c.id as scanid
             FROM {local_a11y_check_type_pdf} tp
@@ -74,7 +74,7 @@ class pdf {
      * @param int $limit The number of files to process at a time.
      * @return bool
      */
-    public static function remove_deleted_files($limit = 100000) {
+    public static function remove_deleted_files($limit = 5) {
         global $DB;
         // Get all records with a contenthash that exists in the plugin, but does not exist in the mdl_files table.
         // This indicates that the file was deleted.
@@ -105,7 +105,7 @@ class pdf {
      * @param int $limit The number of files to process at a time.
      * @return array
      */
-    public static function get_unscanned_pdf_files(int $offset = 0, int $limit = 100) {
+    public static function get_unscanned_pdf_files(int $offset = 0, int $limit = 5) {
         global $DB;
 
         mtrace("Looking for PDF files to scan for accessibility");
@@ -140,7 +140,7 @@ class pdf {
      * @param int $limit
      * @return array
      */
-    public static function get_pdf_files($limit = 10000) {
+    public static function get_pdf_files($limit = 5) {
 
         global $DB;
 
@@ -281,7 +281,7 @@ class pdf {
      * @param int $limit The limit of records to return. Optional.
      * @return int
      */
-    public static function get_scan_status($scanid, $limit = 5000) {
+    public static function get_scan_status($scanid, $limit = 5) {
         global $DB;
         $sql = "SELECT c.status, c.statustext
             FROM {local_a11y_check} c

--- a/classes/pdf.php
+++ b/classes/pdf.php
@@ -138,8 +138,10 @@ class pdf {
         $sql = "SELECT f.scanid, f.contenthash as contenthash, f.pathnamehash as pathnamehash
             FROM {local_a11y_check_type_pdf} f
             INNER JOIN {local_a11y_check} c ON c.id = f.scanid
-        ";
+            WHERE c.status = " . LOCAL_A11Y_CHECK_STATUS_UNCHECKED;
 
+        mtrace($sql);
+        
         $files = $DB->get_records_sql($sql, null, 0, $limit);
 
         return $files;

--- a/classes/task/find_pdf_files.php
+++ b/classes/task/find_pdf_files.php
@@ -48,20 +48,22 @@ class find_pdf_files extends \core\task\scheduled_task {
      */
     public function execute() {
 
+        // Set the timeout in seconds.
         $timeout = 10;
 
-        $offset = 0;
-
+        // Get the max amount of files to process from the plugin config.
         $limit = (int) get_config('local_a11y_check', 'files_per_cron');
 
-        $files = \local_a11y_check\pdf::get_unscanned_pdf_files($offset, $limit);
+        // Get the unscanned PDF files.
+        $files = \local_a11y_check\pdf::get_unscanned_pdf_files($limit);
 
+        // Only process if there are files to process.
         if (is_array($files) && count($files) > 0) {
             $lockfactory = \core\lock\lock_config::get_lock_factory('local_a11y_check_find_pdf_files_task');
             foreach ($files as $file) {
                 $lockkey = "contenthash: {$file->contenthash}";
                 if ($lock = $lockfactory->get_lock($lockkey, $timeout)) {
-                    // Create the required db records for the file.
+                    // Create records for the file.
                     \local_a11y_check\pdf::provision_db_records($file);
                     $lock->release();
                 } else {

--- a/classes/task/find_pdf_files.php
+++ b/classes/task/find_pdf_files.php
@@ -47,15 +47,22 @@ class find_pdf_files extends \core\task\scheduled_task {
      * Find unscanned PDF files in the Moodle file system.
      */
     public function execute() {
+
         $timeout = 5;
-        $files = \local_a11y_check\pdf::get_unscanned_pdf_files();
+
+        $offset = 0;
+
+        $limit = (int) get_config('local_a11y_check', 'files_per_cron');
+
+        $files = \local_a11y_check\pdf::get_unscanned_pdf_files($offset, $limit);
 
         if (is_array($files) && count($files) > 0) {
             $lockfactory = \core\lock\lock_config::get_lock_factory('local_a11y_check_find_pdf_files_task');
             foreach ($files as $file) {
                 $lockkey = "contenthash: {$file->contenthash}";
                 if ($lock = $lockfactory->get_lock($lockkey, $timeout)) {
-                    \local_a11y_check\pdf::create_scan_record($file);
+                    // Create the required db records for the file.
+                    \local_a11y_check\pdf::provision_db_records($file);
                     $lock->release();
                 } else {
                     throw new \moodle_exception('locktimeout');

--- a/classes/task/find_pdf_files.php
+++ b/classes/task/find_pdf_files.php
@@ -48,7 +48,7 @@ class find_pdf_files extends \core\task\scheduled_task {
      */
     public function execute() {
 
-        $timeout = 5;
+        $timeout = 10;
 
         $offset = 0;
 

--- a/classes/task/scan_pdf_files.php
+++ b/classes/task/scan_pdf_files.php
@@ -54,7 +54,7 @@ class scan_pdf_files extends \core\task\scheduled_task {
         $limit = (int) get_config('local_a11y_check', 'files_per_cron');
 
         mtrace("Scanning " . $limit . " PDF files for accessibility issues.");
-        
+
         // Get the files to scan.
         $files = \local_a11y_check\pdf::get_pdf_files($limit);
 

--- a/classes/task/scan_pdf_files.php
+++ b/classes/task/scan_pdf_files.php
@@ -50,9 +50,15 @@ class scan_pdf_files extends \core\task\scheduled_task {
 
         global $CFG;
 
-        $pluginconfig = get_config('local_a11y_check');
-        $maxfilesize = $pluginconfig->max_file_size_mb;
-        $files = \local_a11y_check\pdf::get_pdf_files();
+        // Get the max amount of files to process from the plugin config.
+        $limit = (int) get_config('local_a11y_check', 'files_per_cron');
+
+        mtrace("Scanning " . $limit . " PDF files for accessibility issues.");
+        
+        // Get the files to scan.
+        $files = \local_a11y_check\pdf::get_pdf_files($limit);
+
+        // Get the file storage handler.
         $fs = get_file_storage();
 
         if (is_array($files) && count($files) > 0) {

--- a/tests/file_discovery_test.php
+++ b/tests/file_discovery_test.php
@@ -48,7 +48,7 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
 
         /*
          * @important
-         * This test will fail if $this->add_pdfs() is called with a value greater 
+         * This test will fail if $this->add_pdfs() is called with a value greater
          * than the plugins max cron limit size.
          */
 
@@ -75,7 +75,7 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
 
         // After the task is run, there should be 0 unscanned files.
         $this->assert_unscanned_files_count(0);
-        
+
         // After the task has run, there should be 5 records created.
         $this->assert_custom_record_count(5);
 

--- a/tests/file_discovery_test.php
+++ b/tests/file_discovery_test.php
@@ -45,6 +45,13 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
     public $filesadded;
 
     public function test_file_discovery() {
+
+        /*
+         * @important
+         * This test will fail if $this->add_pdfs() is called with a value greater 
+         * than the plugins max cron limit size.
+         */
+
         $this->resetAfterTest(true);
         $this->pdfhelper = new \local_a11y_check\pdf();
         $this->task = new \local_a11y_check\task\find_pdf_files();
@@ -72,11 +79,11 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
         // After the task has run, there should be 5 records created.
         $this->assert_custom_record_count(5);
 
-        // Add 7 pdfs.
-        $this->add_pdfs(7);
+        // Add 4 pdfs.
+        $this->add_pdfs(4);
 
         // There should now be 7 unscanned files.
-        $this->assert_unscanned_files_count(7);
+        $this->assert_unscanned_files_count(4);
 
         // Sanity check - There should still be 5 records created.
         $this->assert_custom_record_count(5);
@@ -88,7 +95,7 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
         $this->assert_unscanned_files_count(0);
 
         // There should be 12 records total.
-        $this->assert_custom_record_count(12);
+        $this->assert_custom_record_count(9);
 
     }
 

--- a/tests/file_discovery_test.php
+++ b/tests/file_discovery_test.php
@@ -177,6 +177,8 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
      */
     protected function assert_unscanned_files_count($count) {
         $queryresults = $this->pdfhelper->get_unscanned_pdf_files();
+        mtrace('count is ' . $count);
+        mtrace('queryresults is' . $queryresults);
         return $this->assertEquals($count, count($queryresults));
     }
 }

--- a/tests/file_discovery_test.php
+++ b/tests/file_discovery_test.php
@@ -45,6 +45,10 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
     public $filesadded;
 
     public function test_file_discovery() {
+        // !!
+        // !!IMPORTANT: This test only works if files_cron >= 5
+        // !!
+
         $this->resetAfterTest(true);
         $this->pdfhelper = new \local_a11y_check\pdf();
         $this->task = new \local_a11y_check\task\find_pdf_files();

--- a/tests/file_discovery_test.php
+++ b/tests/file_discovery_test.php
@@ -45,36 +45,51 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
     public $filesadded;
 
     public function test_file_discovery() {
-        // !!
-        // !!IMPORTANT: This test only works if files_cron >= 5
-        // !!
-
         $this->resetAfterTest(true);
         $this->pdfhelper = new \local_a11y_check\pdf();
         $this->task = new \local_a11y_check\task\find_pdf_files();
         $this->course = $this->getDataGenerator()->create_course(array('shortname' => 'testcourse'));
         $this->page = $this->getDataGenerator()->create_module('page', array('course' => $this->course->id));
 
+        // Add files that should be excluded from the scan.
         $this->add_garbage_files();
 
+        // Add 5 pdfs.
         $this->add_pdfs(5);
 
-        $this->assert_custom_record_count(0);
+        // There should be 5 unscanned files.
         $this->assert_unscanned_files_count(5);
 
+        // There should be 0 records created.
+        $this->assert_custom_record_count(0);
+
+        // Execute the task.
         $this->task->execute();
 
-        $this->assert_custom_record_count(5);
+        // After the task is run, there should be 0 unscanned files.
         $this->assert_unscanned_files_count(0);
+        
+        // After the task has run, there should be 5 records created.
+        $this->assert_custom_record_count(5);
 
+        // Add 7 pdfs.
         $this->add_pdfs(7);
 
+        // There should now be 7 unscanned files.
         $this->assert_unscanned_files_count(7);
 
+        // Sanity check - There should still be 5 records created.
+        $this->assert_custom_record_count(5);
+
+        // Execute the task again.
         $this->task->execute();
 
-        $this->assert_custom_record_count(12);
+        // After the task executes, there should be 0 unscanned files.
         $this->assert_unscanned_files_count(0);
+
+        // There should be 12 records total.
+        $this->assert_custom_record_count(12);
+
     }
 
     /**
@@ -164,9 +179,8 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
      */
     protected function assert_custom_record_count($count) {
         global $DB;
-
-        $customrecords = $DB->get_records('local_a11y_check');
-        return $this->assertEquals($count, count($customrecords));
+        $records = $DB->count_records('local_a11y_check');
+        return $this->assertEquals($count, $records);
     }
 
     /**
@@ -176,9 +190,7 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
      * @return boolean
      */
     protected function assert_unscanned_files_count($count) {
-        $queryresults = $this->pdfhelper->get_unscanned_pdf_files();
-        mtrace('count is ' . $count);
-        mtrace('queryresults is' . $queryresults);
+        $queryresults = $this->pdfhelper->get_unscanned_pdf_files(100);
         return $this->assertEquals($count, count($queryresults));
     }
 }

--- a/tests/file_discovery_test.php
+++ b/tests/file_discovery_test.php
@@ -47,7 +47,6 @@ class local_a11y_assert_file_discovery_testcase extends advanced_testcase {
     public function test_file_discovery() {
 
         /*
-         * @important
          * This test will fail if $this->add_pdfs() is called with a value greater
          * than the plugins max cron limit size.
          */

--- a/tests/scan_validity_test.php
+++ b/tests/scan_validity_test.php
@@ -69,7 +69,7 @@ class local_a11y_assert_scan_validity_testcase extends advanced_testcase {
                 // Extract the a11y tokens from the filename.
                 $a11ytokens = explode('-', explode('_', $filename)[1]);
 
-                // Create a blank results object. 
+                // Create a blank results object.
                 // This will be filled with the results.
                 $a11ycheck = new \local_a11y_check\pdf_a11y_results();
 
@@ -79,7 +79,7 @@ class local_a11y_assert_scan_validity_testcase extends advanced_testcase {
                 // Scan the PDF.
                 $results = \local_a11y_check\pdf_scanner::scan($pdf);
 
-                //  Set the results based on the filename tokens.
+                // Set the results based on the filename tokens.
                 if (in_array('TI', $a11ytokens)) {
                     $a11ycheck->hastitle = 1;
                 }

--- a/tests/scan_validity_test.php
+++ b/tests/scan_validity_test.php
@@ -34,15 +34,21 @@ defined('MOODLE_INTERNAL') || die();
 class local_a11y_assert_scan_validity_testcase extends advanced_testcase {
 
     public function test_scan_validity() {
+
+        // Get the directory where all of the PDFs are stored.
         $pdfdir = dirname(__FILE__) . '/fixtures/pdfs';
 
         if (!is_dir($pdfdir)) {
             throw new \Exception("Invalid directory.");
         }
 
+        // Create an arry to store the pdfs.
         $pdfs = array();
+
+        // Get all of the PDFs in the directory.
         $files = array_diff(scandir($pdfdir), array('.', '..'));
 
+        // Iterate through the files, and if the file is a PDF, add it to $pdfs.
         foreach ($files as $file) {
             $fp = $pdfdir . '/' . $file;
             $ext = pathinfo($fp, PATHINFO_EXTENSION);
@@ -60,11 +66,20 @@ class local_a11y_assert_scan_validity_testcase extends advanced_testcase {
 
             if (strpos($filename, '-') !== false) {
 
+                // Extract the a11y tokens from the filename.
                 $a11ytokens = explode('-', explode('_', $filename)[1]);
+
+                // Create a blank results object. 
+                // This will be filled with the results.
                 $a11ycheck = new \local_a11y_check\pdf_a11y_results();
+
+                // Get the file contents of the PDF.
                 $contents = file_get_contents($pdf);
+
+                // Scan the PDF.
                 $results = \local_a11y_check\pdf_scanner::scan($pdf);
 
+                //  Set the results based on the filename tokens.
                 if (in_array('TI', $a11ytokens)) {
                     $a11ycheck->hastitle = 1;
                 }
@@ -81,6 +96,7 @@ class local_a11y_assert_scan_validity_testcase extends advanced_testcase {
                     $a11ycheck->hastext = 1;
                 }
 
+                // Assert that the results match the expected results.
                 $this->assertEquals($a11ycheck->hastitle, $results->hastitle);
                 $this->assertEquals($a11ycheck->hasbookmarks, $results->hasbookmarks);
                 $this->assertEquals($a11ycheck->haslanguage, $results->haslanguage);
@@ -90,4 +106,3 @@ class local_a11y_assert_scan_validity_testcase extends advanced_testcase {
     }
 
 }
-

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021091400;
+$plugin->version   = 2021091604;
 $plugin->requires  = 2020110906;
 $plugin->component = 'local_a11y_check';
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021091604;
+$plugin->version   = 2021091605;
 $plugin->requires  = 2020110906;
 $plugin->component = 'local_a11y_check';
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021090700;
+$plugin->version   = 2021091400;
 $plugin->requires  = 2020110906;
 $plugin->component = 'local_a11y_check';
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021091701;
+$plugin->version   = 2021091702;
 $plugin->requires  = 2020110906;
 $plugin->component = 'local_a11y_check';
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021091605;
+$plugin->version   = 2021091701;
 $plugin->requires  = 2020110906;
 $plugin->component = 'local_a11y_check';
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
This PR makes Moodle follow the "files_per_cron" setting for both finding PDFs and scanning them.